### PR TITLE
update the head branch regex with jira default branch rule

### DIFF
--- a/.github/workflows/pr-updator.yml
+++ b/.github/workflows/pr-updator.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           repo-token: "${{ secrets.token }}"
           base-branch-regex: '[a-z\d-_.\\/]+'
-          head-branch-regex: 'sc-\d+'
+          head-branch-regex: 'SC-\d+'
           title-template: '%headbranch% '


### PR DESCRIPTION
Ths `tzkhan/pr-update-action` action didn't set flags for RegExp by default and we can't specified it, so we have to modify the regexp to `SC-\d+` to match the JIRA default branch naming rule