### PR TITLE
Revert "update the head branch regex with jira default branch rule"

### DIFF
--- a/.github/workflows/pr-updator.yml
+++ b/.github/workflows/pr-updator.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           repo-token: "${{ secrets.token }}"
           base-branch-regex: '[a-z\d-_.\\/]+'
-          head-branch-regex: 'SC-\d+'
+          head-branch-regex: 'sc-\d+'
           title-template: '%headbranch% '


### PR DESCRIPTION
Reverts Gradual-Inc/actions-workflows#2

the branch name is lowercased by default, it should work well without the update